### PR TITLE
Fix bug when keys or values have "," inside

### DIFF
--- a/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
+++ b/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
@@ -77,10 +77,10 @@ class SharedPrefStringRepository implements StringRepository {
 
     private Map<String, String> deserializeKeyValues(String content) {
         Map<String, String> keyValues = new LinkedHashMap<>();
-        String[] items = content.split("(,{1})(?!\1)");
+        String[] items = content.split("\{,\}");
         for (String item : items) {
             String[] itemKeyValue = item.split("=");
-            keyValues.put(itemKeyValue[0].replaceAll(",,", ","), itemKeyValue[1].replaceAll(",,", ","));
+            keyValues.put(itemKeyValue[0], itemKeyValue[1]);
         }
         return keyValues;
     }
@@ -88,12 +88,12 @@ class SharedPrefStringRepository implements StringRepository {
     private String serializeKeyValues(Map<String, String> keyValues) {
         StringBuilder content = new StringBuilder();
         for (Map.Entry<String, String> item : keyValues.entrySet()) {
-            content.append(item.getKey().replaceAll(",", ",,"))
+            content.append(item.getKey())
                     .append("=")
-                    .append(item.getValue().replaceAll(",", ",,"))
-                    .append(",");
+                    .append(item.getValue())
+                    .append("{,}");
         }
-        content.deleteCharAt(content.length() - 1);
+        content.deleteCharAt(content.length() - 3);
         return content.toString();
     }
 }

--- a/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
+++ b/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
@@ -77,10 +77,10 @@ class SharedPrefStringRepository implements StringRepository {
 
     private Map<String, String> deserializeKeyValues(String content) {
         Map<String, String> keyValues = new LinkedHashMap<>();
-        String[] items = content.split(",");
+        String[] items = content.split("(,{1})(?!\1)");
         for (String item : items) {
             String[] itemKeyValue = item.split("=");
-            keyValues.put(itemKeyValue[0], itemKeyValue[1].replaceAll(",,", ","));
+            keyValues.put(itemKeyValue[0].replaceAll(",,", ","), itemKeyValue[1].replaceAll(",,", ","));
         }
         return keyValues;
     }
@@ -88,7 +88,7 @@ class SharedPrefStringRepository implements StringRepository {
     private String serializeKeyValues(Map<String, String> keyValues) {
         StringBuilder content = new StringBuilder();
         for (Map.Entry<String, String> item : keyValues.entrySet()) {
-            content.append(item.getKey())
+            content.append(item.getKey().replaceAll(",", ",,"))
                     .append("=")
                     .append(item.getValue().replaceAll(",", ",,"))
                     .append(",");

--- a/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
+++ b/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
@@ -77,7 +77,7 @@ class SharedPrefStringRepository implements StringRepository {
 
     private Map<String, String> deserializeKeyValues(String content) {
         Map<String, String> keyValues = new LinkedHashMap<>();
-        String[] items = content.split("\{,\}");
+        String[] items = content.split(Pattern.quote("{") +","+Pattern.quote("}"));
         for (String item : items) {
             String[] itemKeyValue = item.split("=");
             keyValues.put(itemKeyValue[0], itemKeyValue[1]);

--- a/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
+++ b/restring/src/main/java/com/ice/restring/SharedPrefStringRepository.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A StringRepository which saves/loads the strings in Shared Preferences.


### PR DESCRIPTION
When serialize or deserialize the translation map and any off the key or values have "," inside it broke the code, I replace the , for {,} so it now work properly